### PR TITLE
Feature map keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.lock
 phpunit.xml
 vendor
 .idea
+

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 composer.lock
 phpunit.xml
 vendor
+.idea

--- a/src/Map/AbstractMap.php
+++ b/src/Map/AbstractMap.php
@@ -44,6 +44,12 @@ abstract class AbstractMap extends AbstractArray implements MapInterface
         return in_array($value, $this->data, true);
     }
 
+    public function keys()
+    {
+        return array_keys($this->data);
+    }
+
+
     public function get($key, $defaultValue = null)
     {
         if (!$this->containsKey($key)) {

--- a/src/Map/AbstractMap.php
+++ b/src/Map/AbstractMap.php
@@ -49,7 +49,6 @@ abstract class AbstractMap extends AbstractArray implements MapInterface
         return array_keys($this->data);
     }
 
-
     public function get($key, $defaultValue = null)
     {
         if (!$this->containsKey($key)) {

--- a/src/Map/MapInterface.php
+++ b/src/Map/MapInterface.php
@@ -42,11 +42,19 @@ interface MapInterface extends ArrayInterface
     public function containsValue($value);
 
     /**
+     * Return an array of the keys contained in this map
+     *
+     * @return array
+     */
+    public function keys();
+
+    /**
      * Returns the value to which the specified key is mapped, `null` if this
      * map contains no mapping for the key, or (optionally) `$defaultValue` if
      * this map contains no mapping for the key
      *
      * @param mixed $key
+     * @param mixed $defaultValue
      * @return mixed|null
      */
     public function get($key, $defaultValue = null);

--- a/tests/src/Map/AssociativeArrayMapTest.php
+++ b/tests/src/Map/AssociativeArrayMapTest.php
@@ -11,7 +11,7 @@ use Ramsey\Collection\Test\TestCase;
 class AssociativeArrayMapTest extends TestCase
 {
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Map elements are key/value pairs; a key must be provided for value 123
      */
     public function testOffsetSetWithEmptyOffsetThrowsException()
@@ -38,6 +38,19 @@ class AssociativeArrayMapTest extends TestCase
         $this->assertTrue($associativeArrayMapObject->containsKey('foo'));
         $this->assertTrue($associativeArrayMapObject->containsKey('bar'));
         $this->assertFalse($associativeArrayMapObject->containsKey('baz'));
+    }
+
+    public function testKeys()
+    {
+        $associativeArrayMapObject = new AssociativeArrayMap();
+        
+        // empty map returns empty array
+        $this->assertEquals([], $associativeArrayMapObject->keys());
+        $associativeArrayMapObject['foo'] = null;
+        $associativeArrayMapObject['bar'] = 321;
+        
+        // array with key-value entries return array containing keys
+        $this->assertEquals(['foo', 'bar'], $associativeArrayMapObject->keys());
     }
 
     public function testContainsValue()
@@ -80,7 +93,7 @@ class AssociativeArrayMapTest extends TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Map elements are key/value pairs; a key must be provided for value 123
      */
     public function testPutWithNullKeyThrowsException()
@@ -105,7 +118,7 @@ class AssociativeArrayMapTest extends TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Map elements are key/value pairs; a key must be provided for value 123
      */
     public function testPutIfAbsentWithNullKeyThrowsException()


### PR DESCRIPTION
Declare `MapInterface::keys` method that mimics java `Map::keySet`, implement it on `AbstractMap` and create tests.