### PR TITLE
Small fixes

### DIFF
--- a/src/AbstractCollection.php
+++ b/src/AbstractCollection.php
@@ -53,7 +53,7 @@ abstract class AbstractCollection extends AbstractArray implements CollectionInt
     public function remove($element)
     {
         if (($position = array_search($element, $this->data, true)) !== false) {
-            $this->offsetUnset($position);
+            unset($this->data[$position]);
 
             return true;
         }

--- a/src/Map/AbstractMap.php
+++ b/src/Map/AbstractMap.php
@@ -55,7 +55,7 @@ abstract class AbstractMap extends AbstractArray implements MapInterface
             return $defaultValue;
         }
 
-        return $this->offsetGet($key);
+        return $this[$key];
     }
 
     public function put($key, $value)

--- a/tests/src/Tool/ValueToStringTraitTest.php
+++ b/tests/src/Tool/ValueToStringTraitTest.php
@@ -5,7 +5,7 @@ use Ramsey\Collection\Test\TestCase;
 use Ramsey\Collection\Tool\ValueToStringTrait;
 
 /**
- * Tests for ValueToStringTraint
+ * Tests for ValueToStringTrait
  */
 class ValueToStringTraitTest extends TestCase
 {


### PR DESCRIPTION
- `AbstractCollection` uses itself as `\ArrayAccess`. It does not call directly `offset[Set/Get/Exists/Unset]` methods. This change accomplish this coding style.
- Rename `ValueToStringTaintTest.php` to `ValueToStringTraitTest.php`