### PR TITLE
Implement Set (specialized collection)

### DIFF
--- a/src/AbstractSet.php
+++ b/src/AbstractSet.php
@@ -1,10 +1,22 @@
 <?php
+/**
+ * This file is part of the ramsey/collection library
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright Copyright (c) Ben Ramsey <ben@benramsey.com>
+ * @license http://opensource.org/licenses/MIT MIT
+ * @link https://benramsey.com/projects/ramsey-collection/ Documentation
+ * @link https://packagist.org/packages/ramsey/collection Packagist
+ * @link https://github.com/ramsey/collection GitHub
+ */
 
 namespace Ramsey\Collection;
 
 /**
- * Class AbstractSet
- * @package Ramsey\Collection
+ * This class contains the logic to make a Collection to not allow duplicated values,
+ * to minimize the effort required to implement this specific type of Collection.
  */
 abstract class AbstractSet extends AbstractCollection
 {
@@ -29,5 +41,4 @@ abstract class AbstractSet extends AbstractCollection
         }
         parent::offsetSet($offset, $value);
     }
-
 }

--- a/src/AbstractSet.php
+++ b/src/AbstractSet.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Ramsey\Collection;
+
+/**
+ * Class AbstractSet
+ * @package Ramsey\Collection
+ */
+abstract class AbstractSet extends AbstractCollection
+{
+    /**
+     * Adds the specified element to this set if it is not already present (optional operation).
+     *
+     * @param mixed $element
+     * @return bool true if this set did not already contain the specified element
+     */
+    public function add($element)
+    {
+        if ($this->contains($element)) {
+            return false;
+        }
+        return parent::add($element);
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        if ($this->contains($value)) {
+            return;
+        }
+        parent::offsetSet($offset, $value);
+    }
+
+}

--- a/src/Set.php
+++ b/src/Set.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Ramsey\Collection;
+
+/**
+ * A Set is a Collection that contains no duplicate elements.
+ *
+ * Great care must be exercised if mutable objects are used as set elements.
+ * The behavior of a Set is not specified if the value of an object is changed in a manner
+ * that affects equals comparisons while the object is an element in the set.
+ *
+ * @package Ramsey\Collection
+ */
+class Set extends AbstractSet
+{
+    /**
+     * The type of elements stored in this set
+     *
+     * A set's type is immutable. For this reason, this property is private
+     *
+     * @var string
+     */
+    private $setType;
+
+    /**
+     * Constructs a Set object of the specified type,
+     * optionally with the specified data
+     *
+     * @param string $setType
+     * @param array $data
+     */
+    public function __construct($setType, array $data = [])
+    {
+        $this->setType = $setType;
+        parent::__construct($data);
+    }
+
+    /**
+     * Returns the type associated with this set
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->setType;
+    }
+}

--- a/src/Set.php
+++ b/src/Set.php
@@ -9,7 +9,18 @@ namespace Ramsey\Collection;
  * The behavior of a Set is not specified if the value of an object is changed in a manner
  * that affects equals comparisons while the object is an element in the set.
  *
- * @package Ramsey\Collection
+ * Example usage:
+ *
+ * ``` php
+ * $foo = new \My\Foo();
+ * $set = new Set(\My\Foo::class);
+ *
+ * $set->add($foo); // returns TRUE, the element don't exists
+ * $set->add($foo); // returns FALSE, the element already exists
+ *
+ * $bar = new \My\Foo();
+ * $set->add($bar); // returns TRUE, $bar !== $foo
+ * ```
  */
 class Set extends AbstractSet
 {

--- a/tests/src/SetTest.php
+++ b/tests/src/SetTest.php
@@ -5,6 +5,7 @@ namespace Ramsey\Collection\Test;
 use Ramsey\Collection\AbstractSet;
 use Ramsey\Collection\CollectionInterface;
 use Ramsey\Collection\Set;
+use Ramsey\Collection\Test\Mock\Foo;
 
 /**
  * Tests for Set class.
@@ -52,5 +53,24 @@ class SetTest extends \PHPUnit_Framework_TestCase
         $this->set[] = 100;
         $this->set[] = 100;
         $this->assertSame([100], $this->set->toArray());
+    }
+
+    public function testUsingEqualButNotIdentical()
+    {
+        $uniqueFoos = new Set(Foo::class);
+
+        // the comparisons are identical (===), not equal(==)
+        $this->assertTrue($uniqueFoos->add(new Foo()));
+        $this->assertTrue($uniqueFoos->add(new Foo()));
+    }
+
+    public function testUsingIdentical()
+    {
+        $uniqueFoos = new Set(Foo::class);
+
+        // the comparisons are identical (===), not equal(==)
+        $identical = new Foo();
+        $this->assertTrue($uniqueFoos->add($identical));
+        $this->assertFalse($uniqueFoos->add($identical));
     }
 }

--- a/tests/src/SetTest.php
+++ b/tests/src/SetTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Ramsey\Collection\Test;
+
+use Ramsey\Collection\AbstractSet;
+use Ramsey\Collection\CollectionInterface;
+use Ramsey\Collection\Set;
+
+/**
+ * Tests for Set class.
+ *
+ * As Set is a Collection with no duplicated elements
+ * it only test the expected behavior.
+ */
+class SetTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var Set */
+    private $set;
+
+    protected function setUp()
+    {
+        $this->set = new Set('int');
+    }
+
+    public function testConstructorInherithance()
+    {
+        $this->assertInstanceOf(CollectionInterface::class, $this->set);
+        $this->assertInstanceOf(AbstractSet::class, $this->set);
+    }
+
+    public function testConstructGetType()
+    {
+        $this->assertSame('int', $this->set->getType());
+    }
+
+    public function testConstructWithValues()
+    {
+        $expected = [2, 4, 6, 8];
+        $localSet = new Set('int', $expected);
+        $this->assertEquals($expected, $localSet->toArray());
+    }
+
+    public function testAddDuplicates()
+    {
+        $this->assertTrue($this->set->add(100));
+        $this->assertFalse($this->set->add(100));
+        $this->assertSame([100], $this->set->toArray());
+    }
+
+    public function testOffsetSetDuplicates()
+    {
+        $this->set[] = 100;
+        $this->set[] = 100;
+        $this->assertSame([100], $this->set->toArray());
+    }
+}

--- a/tests/src/SetTest.php
+++ b/tests/src/SetTest.php
@@ -23,7 +23,7 @@ class SetTest extends \PHPUnit_Framework_TestCase
         $this->set = new Set('int');
     }
 
-    public function testConstructorInherithance()
+    public function testConstructorInheritance()
     {
         $this->assertInstanceOf(CollectionInterface::class, $this->set);
         $this->assertInstanceOf(AbstractSet::class, $this->set);


### PR DESCRIPTION
Implements `Set`: A `Collection` with no duplicated values.
```php
$set = new Set('int', [3, 2, 1, 2]); // only contains [3, 2, 1]
```

Inheritance:
`Set <- AbstractSet <- AbstractCollection <- CollectionInterface`
