### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,14 @@ language: php
 php:
   - 5.6
   - 7.0
+  - 7.1
+  - 7.2
   - hhvm
+  - nightly
+
+matrix:
+  allow_failures:
+    - php: nightly
 
 sudo: false
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=5.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0",
+        "phpunit/phpunit": "^5.0||^6.5",
         "squizlabs/php_codesniffer": "^2.3",
         "jakub-onderka/php-parallel-lint": "^0.9.0",
         "satooshi/php-coveralls": "^0.6.1",

--- a/tests/src/GenericArrayTest.php
+++ b/tests/src/GenericArrayTest.php
@@ -31,7 +31,7 @@ class GenericArrayTest extends TestCase
     {
         $genericArrayObject = new GenericArray();
 
-        $this->assertInstanceOf('ArrayIterator', $genericArrayObject->getIterator());
+        $this->assertInstanceOf(\ArrayIterator::class, $genericArrayObject->getIterator());
     }
 
     public function testArrayAccess()
@@ -79,7 +79,7 @@ class GenericArrayTest extends TestCase
         $genericArrayObjectSerialized = serialize($genericArrayObject);
         $genericArrayObject2 = unserialize($genericArrayObjectSerialized);
 
-        $this->assertInstanceOf('Ramsey\\Collection\\ArrayInterface', $genericArrayObject2);
+        $this->assertInstanceOf(\Ramsey\Collection\ArrayInterface::class, $genericArrayObject2);
         $this->assertEquals($genericArrayObject, $genericArrayObject2);
     }
 

--- a/tests/src/Map/AssociativeArrayMapTest.php
+++ b/tests/src/Map/AssociativeArrayMapTest.php
@@ -10,13 +10,12 @@ use Ramsey\Collection\Test\TestCase;
  */
 class AssociativeArrayMapTest extends TestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Map elements are key/value pairs; a key must be provided for value 123
-     */
     public function testOffsetSetWithEmptyOffsetThrowsException()
     {
         $associativeArrayMapObject = new AssociativeArrayMap();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Map elements are key/value pairs; a key must be provided for value 123');
         $associativeArrayMapObject[] = 123;
     }
 
@@ -92,13 +91,12 @@ class AssociativeArrayMapTest extends TestCase
         $this->assertEquals(456, $associativeArrayMapObject->get('foo'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Map elements are key/value pairs; a key must be provided for value 123
-     */
     public function testPutWithNullKeyThrowsException()
     {
         $associativeArrayMapObject = new AssociativeArrayMap();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Map elements are key/value pairs; a key must be provided for value 123');
         $previousValue = $associativeArrayMapObject->put(null, 123);
     }
 
@@ -117,13 +115,12 @@ class AssociativeArrayMapTest extends TestCase
         $this->assertEquals(123, $associativeArrayMapObject->get('foo'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Map elements are key/value pairs; a key must be provided for value 123
-     */
     public function testPutIfAbsentWithNullKeyThrowsException()
     {
         $associativeArrayMapObject = new AssociativeArrayMap();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Map elements are key/value pairs; a key must be provided for value 123');
         $previousValue = $associativeArrayMapObject->putIfAbsent(null, 123);
     }
 

--- a/tests/src/Map/NamedParameterMapTest.php
+++ b/tests/src/Map/NamedParameterMapTest.php
@@ -81,33 +81,30 @@ class NamedParameterMapTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Attempting to set value for unconfigured parameter 'bar'
-     */
     public function testNamedParametersWithUnnamedParameterThrowException()
     {
         $namedParameterMap = new NamedParameterMap(['foo']);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Attempting to set value for unconfigured parameter \'bar\'');
         $namedParameterMap['bar'] = 123;
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Value for 'foo' must be of type int
-     */
     public function testNamedParametersWithWrongTypeThrowsException()
     {
         $namedParameterMap = new NamedParameterMap(['foo' => 'int']);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Value for \'foo\' must be of type int');
         $namedParameterMap['foo'] = $this->faker->text();
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Value for 'foo' must be of type int
-     */
     public function testNamedParameterWithNoStringValue()
     {
         $namedParameterMap = new NamedParameterMap(['foo' => 'int']);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Value for \'foo\' must be of type int');
         $namedParameterMap['foo'] = new \DateTime();
     }
 }

--- a/tests/src/SetTest.php
+++ b/tests/src/SetTest.php
@@ -6,6 +6,7 @@ use Ramsey\Collection\AbstractSet;
 use Ramsey\Collection\CollectionInterface;
 use Ramsey\Collection\Set;
 use Ramsey\Collection\Test\Mock\Foo;
+use PHPUnit\Framework\TestCase as PhpUnitTestCase;
 
 /**
  * Tests for Set class.
@@ -13,7 +14,7 @@ use Ramsey\Collection\Test\Mock\Foo;
  * As Set is a Collection with no duplicated elements
  * it only test the expected behavior.
  */
-class SetTest extends \PHPUnit_Framework_TestCase
+class SetTest extends PhpUnitTestCase
 {
     /** @var Set */
     private $set;

--- a/tests/src/TestCase.php
+++ b/tests/src/TestCase.php
@@ -1,7 +1,9 @@
 <?php
 namespace Ramsey\Collection\Test;
 
-class TestCase extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase as PhpUnitTestCase;
+
+class TestCase extends PhpUnitTestCase
 {
     protected $faker;
 


### PR DESCRIPTION
# Changed log
- Set muiltiple PHPUnit versions to support diffeent PHP versions.
- Set the nightly test and accept this can be failed in Travis CI build.
- Add the ```php-7.2``` test in Travis CI build.
- Use the class-based PHPUnit namespace to support the stable PHPUnit version.
- Add more tests.
- Unite the exception expectation approach.