### PR TITLE
Upgrade PHPUnit to 7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=7.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0||^6.5",
+        "phpunit/phpunit": "^7.3",
         "squizlabs/php_codesniffer": "^3.3",
         "jakub-onderka/php-parallel-lint": "^0.9.0",
         "satooshi/php-coveralls": "^0.6.1",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="./vendor/autoload.php" colors="true" verbose="true">
     <testsuites>
-        <testsuite>
+        <testsuite name="ramsey/collection unit tests">
             <directory>./tests</directory>
         </testsuite>
     </testsuites>


### PR DESCRIPTION
Issue #14 

A PR to bump the PHP minimum version to 7.2 is required to make this PR valid. Since there are already a number of duplicated PRs for various issues, I did not want to make another duplicate.

PR #25 should suffice to make this merge, but in order for that one to pass a PR to remove HHVM is needed first. PR #26 will cover that.