### PR TITLE
Correct offset Setter

### DIFF
--- a/src/AbstractCollection.php
+++ b/src/AbstractCollection.php
@@ -81,7 +81,11 @@ abstract class AbstractCollection extends AbstractArray implements CollectionInt
             );
         }
 
-        $this->data[] = $value;
+        if ($offset === null) {
+            $this->data[] = $value;
+        } else {
+            $this->data[$offset] = $value;
+        }
     }
 
     /**

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -43,6 +43,17 @@ class CollectionTest extends TestCase
         $collection[] = $this->faker->text();
     }
 
+    public function testOffsetSetPosition(): void
+    {
+        $offset = $this->faker->numberBetween(0, 100);
+        $value = $this->faker->numberBetween(0, 100);
+
+        $collection = new Collection('int');
+        $collection->offsetSet($offset, $value);
+
+        $this->assertSame($value, $collection->offsetGet($offset));
+    }
+
     public function testAdd(): void
     {
         $collection = new Collection('integer');


### PR DESCRIPTION
## Description
Small bug- fix that allows to setup correct offset in the collection.

## Motivation and Context
Broken method does not allow developer to setup correct offset (but param is already in signature).

## How Has This Been Tested?
Tests passes. I've added one more specific test for this changes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I ran `composer test` locally and there were no failures or errors.
