### PR TITLE
Bug - AbstractCollection::diff()/AbstractCollection::intersect() returns unexpected results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Deprecated
 ### Removed
 ### Fixed
+
+* Fixed `AbstractCollection::diff()` and `AbstractCollection::intersect()`
+  returning inconsistent results when used on collections containing objects.
+
 ### Security
 
 ## [1.0.1] - 2020-01-04

--- a/src/AbstractCollection.php
+++ b/src/AbstractCollection.php
@@ -285,7 +285,17 @@ abstract class AbstractCollection extends AbstractArray implements CollectionInt
         }
 
         $comparator = function ($a, $b) {
-            return $a === $b ? 0 : -1;
+            // If the two values are object, we convert them to unique scalars.
+            // If the collection contains mixed values (unlikely) where some are objects
+            // and some are not, we leave them as they are.
+            // The comparator should still work and the result of $a < $b should
+            // be consistent but unpredictable since not documented.
+            if (is_object($a) && is_object($b)) {
+                $a = spl_object_id($a);
+                $b = spl_object_id($b);
+            }
+
+            return $a === $b ? 0 : ($a < $b ? 1 : -1);
         };
 
         $diffAtoB = array_udiff($this->data, $other->data, $comparator);
@@ -312,9 +322,21 @@ abstract class AbstractCollection extends AbstractArray implements CollectionInt
             throw new CollectionMismatchException('Collection must be of type ' . static::class);
         }
 
-        $intersect = array_uintersect($this->data, $other->data, function ($a, $b) {
-            return $a === $b ? 0 : -1;
-        });
+        $comparator = function ($a, $b) {
+            // If the two values are object, we convert them to unique scalars.
+            // If the collection contains mixed values (unlikely) where some are objects
+            // and some are not, we leave them as they are.
+            // The comparator should still work and the result of $a < $b should
+            // be consistent but unpredictable since not documented.
+            if (is_object($a) && is_object($b)) {
+                $a = spl_object_id($a);
+                $b = spl_object_id($b);
+            }
+
+            return $a === $b ? 0 : ($a < $b ? 1 : -1);
+        };
+
+        $intersect = array_uintersect($this->data, $other->data, $comparator);
 
         return new static($intersect);
     }

--- a/tests/CollectionManipulationTest.php
+++ b/tests/CollectionManipulationTest.php
@@ -193,15 +193,25 @@ class CollectionManipulationTest extends TestCase
 
         $barCollection1 = new BarCollection([$bar1]);
         $barCollection2 = new BarCollection([$bar1, $bar2]);
+        $barCollection3 = new BarCollection([$bar2, $bar1]);
 
-        $diffCollection = $barCollection1->diff($barCollection2);
+        $diffCollection1 = $barCollection1->diff($barCollection2);
+        $diffCollection2 = $barCollection1->diff($barCollection3);
 
-        $this->assertNotSame($diffCollection, $barCollection1);
-        $this->assertNotSame($diffCollection, $barCollection2);
-        $this->assertEquals([$bar2], $diffCollection->toArray());
+        $this->assertNotSame($diffCollection1, $barCollection1);
+        $this->assertNotSame($diffCollection1, $barCollection2);
+        $this->assertNotSame($diffCollection1, $barCollection3);
+        $this->assertEquals([$bar2], $diffCollection1->toArray());
+
+        $this->assertNotSame($diffCollection2, $barCollection1);
+        $this->assertNotSame($diffCollection2, $barCollection2);
+        $this->assertNotSame($diffCollection2, $barCollection3);
+        $this->assertEquals([$bar2], $diffCollection2->toArray());
+
         // Make sure original collections are untouched
         $this->assertEquals([$bar1], $barCollection1->toArray());
         $this->assertEquals([$bar1, $bar2], $barCollection2->toArray());
+        $this->assertEquals([$bar2, $bar1], $barCollection3->toArray());
     }
 
     public function testIntersectShouldRaiseExceptionOnDiverseCollections(): void
@@ -218,18 +228,29 @@ class CollectionManipulationTest extends TestCase
     {
         $bar1 = new Bar(1, 'a');
         $bar2 = new Bar(2, 'b');
+        $bar3 = new Bar(3, 'c');
 
-        $barCollection1 = new BarCollection([$bar1]);
-        $barCollection2 = new BarCollection([$bar1, $bar2]);
+        $barCollection1 = new BarCollection([$bar1, $bar2]);
+        $barCollection2 = new BarCollection([$bar1, $bar2, $bar3]);
+        $barCollection3 = new BarCollection([$bar3, $bar2, $bar1]);
 
-        $intersectCollection = $barCollection1->intersect($barCollection2);
+        $intersectCollection1 = $barCollection1->intersect($barCollection2);
+        $intersectCollection2 = $barCollection1->intersect($barCollection3);
 
-        $this->assertNotSame($intersectCollection, $barCollection1);
-        $this->assertNotSame($intersectCollection, $barCollection2);
-        $this->assertEquals([$bar1], $intersectCollection->toArray());
+        $this->assertNotSame($intersectCollection1, $barCollection1);
+        $this->assertNotSame($intersectCollection1, $barCollection2);
+        $this->assertNotSame($intersectCollection1, $barCollection3);
+        $this->assertEquals([$bar1, $bar2], $intersectCollection1->toArray());
+
+        $this->assertNotSame($intersectCollection2, $barCollection1);
+        $this->assertNotSame($intersectCollection2, $barCollection2);
+        $this->assertNotSame($intersectCollection2, $barCollection3);
+        $this->assertEquals([$bar1, $bar2], $intersectCollection2->toArray());
+
         // Make sure original collections are untouched
-        $this->assertEquals([$bar1], $barCollection1->toArray());
-        $this->assertEquals([$bar1, $bar2], $barCollection2->toArray());
+        $this->assertEquals([$bar1, $bar2], $barCollection1->toArray());
+        $this->assertEquals([$bar1, $bar2, $bar3], $barCollection2->toArray());
+        $this->assertEquals([$bar3, $bar2, $bar1], $barCollection3->toArray());
     }
 
     public function testMergeShouldRaiseExceptionOnDiverseCollection(): void

--- a/tests/DoubleEndedQueueTest.php
+++ b/tests/DoubleEndedQueueTest.php
@@ -30,7 +30,7 @@ class DoubleEndedQueueTest extends TestCase
         $queue = $this->queue('string', ['Bar']);
 
         $this->assertTrue($queue->addFirst('Foo'));
-        $this->assertSame(2, $queue->count());
+        $this->assertCount(2, $queue);
         $this->assertSame('Foo', $queue->firstElement());
         $this->assertSame('Bar', $queue->lastElement());
     }
@@ -49,7 +49,7 @@ class DoubleEndedQueueTest extends TestCase
         $queue = $this->queue('string', ['Bar']);
 
         $this->assertTrue($queue->addLast('Foo'));
-        $this->assertSame(2, $queue->count());
+        $this->assertCount(2, $queue);
         $this->assertSame('Bar', $queue->firstElement());
         $this->assertSame('Foo', $queue->lastElement());
     }
@@ -60,7 +60,7 @@ class DoubleEndedQueueTest extends TestCase
 
         $this->assertSame('foo', $queue->firstElement());
         $this->assertSame('foo', $queue->firstElement());
-        $this->assertSame(2, $queue->count());
+        $this->assertCount(2, $queue);
     }
 
     public function testLastElementDontRemoveFromQueue(): void
@@ -69,7 +69,7 @@ class DoubleEndedQueueTest extends TestCase
 
         $this->assertSame('bar', $queue->lastElement());
         $this->assertSame('bar', $queue->lastElement());
-        $this->assertSame(2, $queue->count());
+        $this->assertCount(2, $queue);
     }
 
     public function testFirstElementThrowsExceptionIfEmpty(): void
@@ -126,22 +126,22 @@ class DoubleEndedQueueTest extends TestCase
     {
         $queue = $this->queue('string', ['foo', 'bar']);
 
-        $this->assertSame(2, $queue->count());
+        $this->assertCount(2, $queue);
         $this->assertSame('foo', $queue->pollFirst());
-        $this->assertSame(1, $queue->count());
+        $this->assertCount(1, $queue);
         $this->assertSame('bar', $queue->pollFirst());
-        $this->assertSame(0, $queue->count());
+        $this->assertCount(0, $queue);
     }
 
     public function testPollLastRemovesTheTail(): void
     {
         $queue = $this->queue('string', ['foo', 'bar']);
 
-        $this->assertSame(2, $queue->count());
+        $this->assertCount(2, $queue);
         $this->assertSame('bar', $queue->pollLast());
-        $this->assertSame(1, $queue->count());
+        $this->assertCount(1, $queue);
         $this->assertSame('foo', $queue->pollLast());
-        $this->assertSame(0, $queue->count());
+        $this->assertCount(0, $queue);
     }
 
     public function testPollFirstReturnsNullIfEmpty(): void
@@ -162,9 +162,9 @@ class DoubleEndedQueueTest extends TestCase
     {
         $queue = $this->queue('string', ['foo', 'bar', 'biz']);
 
-        $this->assertSame(3, $queue->count());
+        $this->assertCount(3, $queue);
         $this->assertSame('foo', $queue->removeFirst());
-        $this->assertSame(2, $queue->count());
+        $this->assertCount(2, $queue);
         $this->assertSame('bar', $queue->firstElement());
         $this->assertSame('biz', $queue->lastElement());
     }
@@ -173,9 +173,9 @@ class DoubleEndedQueueTest extends TestCase
     {
         $queue = $this->queue('string', ['foo', 'bar', 'biz']);
 
-        $this->assertSame(3, $queue->count());
+        $this->assertCount(3, $queue);
         $this->assertSame('biz', $queue->removeLast());
-        $this->assertSame(2, $queue->count());
+        $this->assertCount(2, $queue);
         $this->assertSame('foo', $queue->firstElement());
         $this->assertSame('bar', $queue->lastElement());
     }
@@ -241,7 +241,7 @@ class DoubleEndedQueueTest extends TestCase
 
         // deque should contain: bar, yop
 
-        $this->assertSame(2, $deque->count());
+        $this->assertCount(2, $deque);
         $this->assertSame('bar', $deque->firstElement());
         $this->assertSame('yop', $deque->lastElement());
     }

--- a/tests/QueueBehavior.php
+++ b/tests/QueueBehavior.php
@@ -27,7 +27,7 @@ trait QueueBehavior
     {
         $queue = $this->queue('string', ['Foo', 'Bar']);
 
-        $this->assertEquals(2, $queue->count());
+        $this->assertCount(2, $queue);
     }
 
     public function testOffsetSet(): void
@@ -35,7 +35,7 @@ trait QueueBehavior
         $queue = $this->queue('string');
         $queue[] = $this->faker->text();
 
-        $this->assertSame(1, $queue->count());
+        $this->assertCount(1, $queue);
     }
 
     public function testOffsetSetThrowsException(): void
@@ -52,7 +52,7 @@ trait QueueBehavior
         $queue = $this->queue('string');
 
         $this->assertTrue($queue->add('Foo'));
-        $this->assertSame(1, $queue->count());
+        $this->assertCount(1, $queue);
     }
 
     public function testAddMayAddSameObjectMultipleTimes(): void
@@ -88,7 +88,7 @@ trait QueueBehavior
 
         $queue->offer($object);
 
-        $this->assertSame(1, $queue->count());
+        $this->assertCount(1, $queue);
         $this->assertSame($object, $queue->poll());
     }
 
@@ -123,7 +123,7 @@ trait QueueBehavior
 
         $this->assertSame($object1, $queue->element());
         $this->assertSame($object1, $queue->element());
-        $this->assertSame(2, $queue->count());
+        $this->assertCount(2, $queue);
     }
 
     public function testElementThrowsExceptionIfEmpty(): void
@@ -166,11 +166,11 @@ trait QueueBehavior
         $queue->add('Foo');
         $queue->add('Bar');
 
-        $this->assertSame(2, $queue->count());
+        $this->assertCount(2, $queue);
         $this->assertSame('Foo', $queue->poll());
-        $this->assertSame(1, $queue->count());
+        $this->assertCount(1, $queue);
         $this->assertSame('Bar', $queue->poll());
-        $this->assertSame(0, $queue->count());
+        $this->assertCount(0, $queue);
     }
 
     public function testPollReturnsNullIfEmpty(): void
@@ -192,9 +192,9 @@ trait QueueBehavior
         $queue->add($obj1);
         $queue->add($obj1);
 
-        $this->assertSame(3, $queue->count());
+        $this->assertCount(3, $queue);
         $this->assertSame($obj1, $queue->remove());
-        $this->assertSame(2, $queue->count());
+        $this->assertCount(2, $queue);
     }
 
     public function testRemoveThrowsExceptionIfEmpty(): void
@@ -237,6 +237,6 @@ trait QueueBehavior
 
         $this->assertSame('Foo', $queue->remove());
 
-        $this->assertSame(1, $queue->count());
+        $this->assertCount(1, $queue);
     }
 }


### PR DESCRIPTION
The result of a diff operation is not always right.
For example, given
```php
// omitted
$bar1 = new Bar('one');
$bar2 = new Bar('two');
$collection1 = new BarCollection([$bar1]);
$collection2 = new BarCollection([$bar1, $bar2]);
$collection3 = new BarCollection([$bar2, $bar1]);

print_r($collection1->diff($collection2));
print_r($collection1->diff($collection3));
```
both diff should return the same result but only the first one is correct.

Similar consideration applies to AbstractCollection::intersect().

## Description
The reason lies in the way array_udiff and array_uintersect work. 
Php uses the comparator callback to sort both lists in order to minimise the number of steps.
If the sorting algorithm is not consistent, the comparator could skip some of the items and returns the wrong result at the end.

I had to make a decision (see comment in the code) when comparing objects since $a < $b would already work but it's not documented. Please, let me know if it could work or it needs further changes.

## Motivation and Context
Fixes #54

## How Has This Been Tested?
It contains unit tests for both changes, the same test run on version 1.0.1 would fail due to the bug.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I ran `composer test` locally and there were no failures or errors.
