### PR TITLE
Allow PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "source": "https://github.com/ramsey/collection"
     },
     "require": {
-        "php": "^7.2"
+        "php": "^7.2 || ^8"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",


### PR DESCRIPTION
The upstream package https://packagist.org/packages/ramsey/uuid#4.0.0 allows php 8, but it need not bother, if it's dependencies don't allow it. So, either we should remove php 8 from the uuid package, or add it in here. ;)