### PR TITLE
Add Traversable<T> return type to getIterator()

### DIFF
--- a/src/AbstractArray.php
+++ b/src/AbstractArray.php
@@ -54,6 +54,8 @@ abstract class AbstractArray implements ArrayInterface
      * Returns an iterator for this array.
      *
      * @link http://php.net/manual/en/iteratoraggregate.getiterator.php IteratorAggregate::getIterator()
+     *
+     * @return Traversable<T>
      */
     public function getIterator(): Traversable
     {


### PR DESCRIPTION
Without that PHPStan will complain about missing `iterable` type specification for subclasses, even if they specify the type T.