### PR TITLE
TypedMap: Fix typo in class phpdoc

### DIFF
--- a/src/Map/TypedMap.php
+++ b/src/Map/TypedMap.php
@@ -20,7 +20,7 @@ use Ramsey\Collection\Tool\TypeTrait;
  * A `TypedMap` represents a map of elements where key and value are typed.
  *
  * Each element is identified by a key with defined type and a value of defined
- * type. The keys of the map must be unique. The values on the map can be=
+ * type. The keys of the map must be unique. The values on the map can be
  * repeated but each with its own different key.
  *
  * The most common case is to use a string type key, but it's not limited to


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Removed the leading `=` sign at the end of line 23

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have run `composer br:test:all` locally, and there were no failures or errors.
