### PR TITLE
Improve some PHPUnit assertions

### DIFF
--- a/tests/CollectionManipulationTest.php
+++ b/tests/CollectionManipulationTest.php
@@ -33,9 +33,9 @@ class CollectionManipulationTest extends TestCase
         $sortedCollection = $barCollection->sort('name');
 
         $this->assertNotSame($barCollection, $sortedCollection);
-        $this->assertEquals([$bar1, $bar2, $bar3], $sortedCollection->toArray());
+        $this->assertSame([$bar1, $bar2, $bar3], $sortedCollection->toArray());
         // Make sure original collection is untouched
-        $this->assertEquals([$bar3, $bar2, $bar1], $barCollection->toArray());
+        $this->assertSame([$bar3, $bar2, $bar1], $barCollection->toArray());
     }
 
     public function testSortNameAscWithDescendingNames(): void
@@ -48,9 +48,9 @@ class CollectionManipulationTest extends TestCase
         $sortedCollection = $barCollection->sort('name');
 
         $this->assertNotSame($barCollection, $sortedCollection);
-        $this->assertEquals([$bar3, $bar2, $bar1], $sortedCollection->toArray());
+        $this->assertSame([$bar3, $bar2, $bar1], $sortedCollection->toArray());
         // Make sure original collection is untouched
-        $this->assertEquals([$bar1, $bar2, $bar3], $barCollection->toArray());
+        $this->assertSame([$bar1, $bar2, $bar3], $barCollection->toArray());
     }
 
     public function testSortNameDescWithDescendingNames(): void
@@ -63,9 +63,9 @@ class CollectionManipulationTest extends TestCase
         $sortedCollection = $barCollection->sort('name', 'desc');
 
         $this->assertNotSame($barCollection, $sortedCollection);
-        $this->assertEquals([$bar1, $bar2, $bar3], $sortedCollection->toArray());
+        $this->assertSame([$bar1, $bar2, $bar3], $sortedCollection->toArray());
         // Make sure original collection is untouched
-        $this->assertEquals([$bar1, $bar2, $bar3], $barCollection->toArray());
+        $this->assertSame([$bar1, $bar2, $bar3], $barCollection->toArray());
     }
 
     public function testSortNameDescWithMethod(): void
@@ -78,9 +78,9 @@ class CollectionManipulationTest extends TestCase
         $sortedCollection = $barCollection->sort('getName', 'desc');
 
         $this->assertNotSame($barCollection, $sortedCollection);
-        $this->assertEquals([$bar1, $bar2, $bar3], $sortedCollection->toArray());
+        $this->assertSame([$bar1, $bar2, $bar3], $sortedCollection->toArray());
         // Make sure original collection is untouched
-        $this->assertEquals([$bar1, $bar2, $bar3], $barCollection->toArray());
+        $this->assertSame([$bar1, $bar2, $bar3], $barCollection->toArray());
     }
 
     public function testSortNameWithInvalidProperty(): void
@@ -116,10 +116,10 @@ class CollectionManipulationTest extends TestCase
         });
 
         $this->assertNotSame($barCollection, $filteredCollection);
-        $this->assertEquals([$bar1], $filteredCollection->toArray());
+        $this->assertSame([$bar1], $filteredCollection->toArray());
 
         // Make sure original collection is untouched
-        $this->assertEquals([$bar1, $bar2], $barCollection->toArray());
+        $this->assertSame([$bar1, $bar2], $barCollection->toArray());
     }
 
     public function testWhereWithTypeSafePropertyValue(): void
@@ -131,9 +131,9 @@ class CollectionManipulationTest extends TestCase
         $whereCollection = $barCollection->where('name', 'b');
 
         $this->assertNotSame($barCollection, $whereCollection);
-        $this->assertEquals([$bar2], $whereCollection->toArray());
+        $this->assertSame([$bar2], $whereCollection->toArray());
         // Make sure original collection is untouched
-        $this->assertEquals([$bar1, $bar2], $barCollection->toArray());
+        $this->assertSame([$bar1, $bar2], $barCollection->toArray());
     }
 
     public function testWhereWithTypeUnsafePropertyValue(): void
@@ -145,9 +145,9 @@ class CollectionManipulationTest extends TestCase
         $whereCollection = $barCollection->where('id', '1');
 
         $this->assertNotSame($barCollection, $whereCollection);
-        $this->assertEquals([], $whereCollection->toArray());
+        $this->assertSame([], $whereCollection->toArray());
         // Make sure original collection is untouched
-        $this->assertEquals([$bar1, $bar2], $barCollection->toArray());
+        $this->assertSame([$bar1, $bar2], $barCollection->toArray());
     }
 
     public function testWhereWithTypeSafeMethodValue(): void
@@ -159,9 +159,9 @@ class CollectionManipulationTest extends TestCase
         $whereCollection = $barCollection->where('getName', 'b');
 
         $this->assertNotSame($barCollection, $whereCollection);
-        $this->assertEquals([$bar2], $whereCollection->toArray());
+        $this->assertSame([$bar2], $whereCollection->toArray());
         // Make sure original collection is untouched
-        $this->assertEquals([$bar1, $bar2], $barCollection->toArray());
+        $this->assertSame([$bar1, $bar2], $barCollection->toArray());
     }
 
     public function testMapShouldRunOverEachItem(): void
@@ -238,17 +238,17 @@ class CollectionManipulationTest extends TestCase
         $this->assertNotSame($diffCollection1, $barCollection1);
         $this->assertNotSame($diffCollection1, $barCollection2);
         $this->assertNotSame($diffCollection1, $barCollection3);
-        $this->assertEquals([$bar2], $diffCollection1->toArray());
+        $this->assertSame([$bar2], $diffCollection1->toArray());
 
         $this->assertNotSame($diffCollection2, $barCollection1);
         $this->assertNotSame($diffCollection2, $barCollection2);
         $this->assertNotSame($diffCollection2, $barCollection3);
-        $this->assertEquals([$bar2], $diffCollection2->toArray());
+        $this->assertSame([$bar2], $diffCollection2->toArray());
 
         // Make sure original collections are untouched
-        $this->assertEquals([$bar1], $barCollection1->toArray());
-        $this->assertEquals([$bar1, $bar2], $barCollection2->toArray());
-        $this->assertEquals([$bar2, $bar1], $barCollection3->toArray());
+        $this->assertSame([$bar1], $barCollection1->toArray());
+        $this->assertSame([$bar1, $bar2], $barCollection2->toArray());
+        $this->assertSame([$bar2, $bar1], $barCollection3->toArray());
     }
 
     public function testdiffShouldRaiseExceptionOnDiverseCollectionType(): void
@@ -274,7 +274,7 @@ class CollectionManipulationTest extends TestCase
 
         $diffCollection = $barCollection1->diff($barCollection2);
 
-        $this->assertEquals([$bar2], $diffCollection->toArray());
+        $this->assertSame([$bar2], $diffCollection->toArray());
     }
 
     public function testIntersectShouldRaiseExceptionOnDiverseCollections(): void
@@ -304,17 +304,17 @@ class CollectionManipulationTest extends TestCase
         $this->assertNotSame($intersectCollection1, $barCollection1);
         $this->assertNotSame($intersectCollection1, $barCollection2);
         $this->assertNotSame($intersectCollection1, $barCollection3);
-        $this->assertEquals([$bar1, $bar2], $intersectCollection1->toArray());
+        $this->assertSame([$bar1, $bar2], $intersectCollection1->toArray());
 
         $this->assertNotSame($intersectCollection2, $barCollection1);
         $this->assertNotSame($intersectCollection2, $barCollection2);
         $this->assertNotSame($intersectCollection2, $barCollection3);
-        $this->assertEquals([$bar1, $bar2], $intersectCollection2->toArray());
+        $this->assertSame([$bar1, $bar2], $intersectCollection2->toArray());
 
         // Make sure original collections are untouched
-        $this->assertEquals([$bar1, $bar2], $barCollection1->toArray());
-        $this->assertEquals([$bar1, $bar2, $bar3], $barCollection2->toArray());
-        $this->assertEquals([$bar3, $bar2, $bar1], $barCollection3->toArray());
+        $this->assertSame([$bar1, $bar2], $barCollection1->toArray());
+        $this->assertSame([$bar1, $bar2, $bar3], $barCollection2->toArray());
+        $this->assertSame([$bar3, $bar2, $bar1], $barCollection3->toArray());
     }
 
     public function testIntersectShouldRaiseExceptionOnDiverseCollectionType(): void
@@ -340,7 +340,7 @@ class CollectionManipulationTest extends TestCase
 
         $diffCollection = $barCollection1->intersect($barCollection2);
 
-        $this->assertEquals([$bar1], $diffCollection->toArray());
+        $this->assertSame([$bar1], $diffCollection->toArray());
     }
 
     public function testMergeShouldRaiseExceptionOnDiverseCollection(): void
@@ -368,12 +368,12 @@ class CollectionManipulationTest extends TestCase
 
         $mergeCollection = $barCollection1->merge($barCollection2, $barCollection3);
         $this->assertNotSame($mergeCollection, $barCollection1);
-        $this->assertEquals([$bar1, $bar2, $bar3], $mergeCollection->toArray());
+        $this->assertSame([$bar1, $bar2, $bar3], $mergeCollection->toArray());
 
         // Make sure the original collections are untouched
-        $this->assertEquals([$bar1], $barCollection1->toArray());
-        $this->assertEquals([$bar2], $barCollection2->toArray());
-        $this->assertEquals([$bar3], $barCollection3->toArray());
+        $this->assertSame([$bar1], $barCollection1->toArray());
+        $this->assertSame([$bar2], $barCollection2->toArray());
+        $this->assertSame([$bar3], $barCollection3->toArray());
     }
 
     public function testMergeWhenTheSameObjectAppearsInMultipleCollections(): void
@@ -387,7 +387,7 @@ class CollectionManipulationTest extends TestCase
         $barCollection3 = new BarCollection([$bar3, $bar2]);
 
         $mergeCollection = $barCollection1->merge($barCollection2, $barCollection3);
-        $this->assertEquals([$bar1, $bar2, $bar1, $bar3, $bar2], $mergeCollection->toArray());
+        $this->assertSame([$bar1, $bar2, $bar1, $bar3, $bar2], $mergeCollection->toArray());
     }
 
     public function testMergeFunctionalityWithKeys(): void
@@ -401,7 +401,7 @@ class CollectionManipulationTest extends TestCase
         $barCollection3 = new BarCollection(['c' => $bar3, 'd' => $bar2]);
 
         $mergeCollection = $barCollection1->merge($barCollection2, $barCollection3);
-        $this->assertEquals(['a' => $bar1, 'b' => $bar2, 'c' => $bar3, 'd' => $bar2], $mergeCollection->toArray());
+        $this->assertSame(['a' => $bar1, 'b' => $bar2, 'c' => $bar3, 'd' => $bar2], $mergeCollection->toArray());
     }
 
     public function testMergeShouldRaiseExceptionOnDiverseCollectionType(): void
@@ -427,7 +427,7 @@ class CollectionManipulationTest extends TestCase
 
         $diffCollection = $barCollection1->merge($barCollection2);
 
-        $this->assertEquals([$bar1, $bar2], $diffCollection->toArray());
+        $this->assertSame([$bar1, $bar2], $diffCollection->toArray());
     }
 
     public function testMapConvertsValues(): void

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -26,7 +26,7 @@ class CollectionTest extends TestCase
     {
         $collection = new Collection('string');
 
-        $this->assertEquals('string', $collection->getType());
+        $this->assertSame('string', $collection->getType());
     }
 
     public function testConstructorWithData(): void
@@ -166,7 +166,7 @@ class CollectionTest extends TestCase
         $bar3 = new Bar(3, 'c');
         $barCollection = new BarCollection([$bar1, $bar2, $bar3]);
 
-        $this->assertEquals(['a', 'b', 'c'], $barCollection->column('name'));
+        $this->assertSame(['a', 'b', 'c'], $barCollection->column('name'));
     }
 
     public function testColumnByMethod(): void
@@ -176,7 +176,7 @@ class CollectionTest extends TestCase
         $bar3 = new Bar(3, 'c');
         $barCollection = new BarCollection([$bar1, $bar2, $bar3]);
 
-        $this->assertEquals([1, 2, 3], $barCollection->column('getId'));
+        $this->assertSame([1, 2, 3], $barCollection->column('getId'));
     }
 
     public function testColumnShouldRaiseExceptionOnUndefinedPropertyOrMethod(): void
@@ -207,7 +207,7 @@ class CollectionTest extends TestCase
 
         $this->assertSame($bar1, $barCollection->first());
         // Make sure the collection stays unchanged
-        $this->assertEquals([$bar1, $bar2, $bar3], $barCollection->toArray());
+        $this->assertSame([$bar1, $bar2, $bar3], $barCollection->toArray());
     }
 
     public function testLastShouldRaiseExceptionOnEmptyCollection(): void
@@ -228,7 +228,7 @@ class CollectionTest extends TestCase
 
         $this->assertSame($bar3, $barCollection->last());
         // Make sure the collection stays unchanged
-        $this->assertEquals([$bar1, $bar2, $bar3], $barCollection->toArray());
+        $this->assertSame([$bar1, $bar2, $bar3], $barCollection->toArray());
     }
 
     public function testSerializable(): void

--- a/tests/GenericArrayTest.php
+++ b/tests/GenericArrayTest.php
@@ -31,7 +31,7 @@ class GenericArrayTest extends TestCase
         $phpArray = ['foo' => 'bar', 'baz'];
         $genericArrayObject = new GenericArray($phpArray);
 
-        $this->assertEquals($phpArray, $genericArrayObject->toArray());
+        $this->assertSame($phpArray, $genericArrayObject->toArray());
         $this->assertFalse($genericArrayObject->isEmpty());
     }
 
@@ -49,12 +49,12 @@ class GenericArrayTest extends TestCase
 
         $this->assertTrue(isset($genericArrayObject['foo']));
         $this->assertFalse(isset($genericArrayObject['bar']));
-        $this->assertEquals($phpArray['foo'], $genericArrayObject['foo']);
+        $this->assertSame($phpArray['foo'], $genericArrayObject['foo']);
 
         $genericArrayObject['bar'] = 456;
         unset($genericArrayObject['foo']);
 
-        $this->assertEquals(456, $genericArrayObject['bar']);
+        $this->assertSame(456, $genericArrayObject['bar']);
         $this->assertArrayNotHasKey('key', $genericArrayObject);
     }
 
@@ -63,7 +63,7 @@ class GenericArrayTest extends TestCase
         $genericArrayObject = new GenericArray();
         $genericArrayObject[] = 123;
 
-        $this->assertEquals(123, $genericArrayObject[0]);
+        $this->assertSame(123, $genericArrayObject[0]);
     }
 
     /**
@@ -104,7 +104,7 @@ class GenericArrayTest extends TestCase
         $phpArray = ['foo' => 'bar'];
         $genericArrayObject = new GenericArray($phpArray);
 
-        $this->assertEquals($phpArray, $genericArrayObject->toArray());
+        $this->assertSame($phpArray, $genericArrayObject->toArray());
 
         $genericArrayObject->clear();
 

--- a/tests/Map/AssociativeArrayMapTest.php
+++ b/tests/Map/AssociativeArrayMapTest.php
@@ -28,7 +28,7 @@ class AssociativeArrayMapTest extends TestCase
         $associativeArrayMapObject = new AssociativeArrayMap();
         $associativeArrayMapObject['foo'] = 123;
 
-        $this->assertEquals(123, $associativeArrayMapObject['foo']);
+        $this->assertSame(123, $associativeArrayMapObject['foo']);
     }
 
     public function testContainsKey(): void
@@ -48,12 +48,12 @@ class AssociativeArrayMapTest extends TestCase
         $associativeArrayMapObject = new AssociativeArrayMap();
 
         // empty map returns empty array
-        $this->assertEquals([], $associativeArrayMapObject->keys());
+        $this->assertSame([], $associativeArrayMapObject->keys());
         $associativeArrayMapObject['foo'] = null;
         $associativeArrayMapObject['bar'] = 321;
 
         // array with key-value entries return array containing keys
-        $this->assertEquals(['foo', 'bar'], $associativeArrayMapObject->keys());
+        $this->assertSame(['foo', 'bar'], $associativeArrayMapObject->keys());
     }
 
     public function testContainsValue(): void
@@ -76,8 +76,8 @@ class AssociativeArrayMapTest extends TestCase
         $data = ['foo' => 123];
         $associativeArrayMapObject = new AssociativeArrayMap($data);
 
-        $this->assertEquals($data['foo'], $associativeArrayMapObject->get('foo'));
-        $this->assertEquals(false, $associativeArrayMapObject->get('bar', false));
+        $this->assertSame($data['foo'], $associativeArrayMapObject->get('foo'));
+        $this->assertFalse($associativeArrayMapObject->get('bar', false));
     }
 
     public function testPut(): void
@@ -89,10 +89,10 @@ class AssociativeArrayMapTest extends TestCase
 
         $previousValue = $associativeArrayMapObject->put('foo', 456);
 
-        $this->assertEquals(123, $previousValue);
+        $this->assertSame(123, $previousValue);
 
         // Ensure the value changed
-        $this->assertEquals(456, $associativeArrayMapObject->get('foo'));
+        $this->assertSame(456, $associativeArrayMapObject->get('foo'));
     }
 
     public function testPutWithNullKeyThrowsException(): void
@@ -115,10 +115,10 @@ class AssociativeArrayMapTest extends TestCase
 
         $currentValue = $associativeArrayMapObject->putIfAbsent('foo', 456);
 
-        $this->assertEquals(123, $currentValue);
+        $this->assertSame(123, $currentValue);
 
         // Ensure the value does not change
-        $this->assertEquals(123, $associativeArrayMapObject->get('foo'));
+        $this->assertSame(123, $associativeArrayMapObject->get('foo'));
     }
 
     public function testPutIfAbsentWithNullKeyThrowsException(): void
@@ -138,7 +138,7 @@ class AssociativeArrayMapTest extends TestCase
         $associativeArrayMapObject = new AssociativeArrayMap($data);
         $previousValue = $associativeArrayMapObject->remove('foo');
 
-        $this->assertEquals($data['foo'], $previousValue);
+        $this->assertSame($data['foo'], $previousValue);
 
         $previousValue = $associativeArrayMapObject->remove('foo');
 
@@ -152,7 +152,7 @@ class AssociativeArrayMapTest extends TestCase
         $associativeArrayMapObject = new AssociativeArrayMap($data);
 
         $this->assertFalse($associativeArrayMapObject->removeIf('foo', 456));
-        $this->assertEquals($data['foo'], $associativeArrayMapObject->get('foo'));
+        $this->assertSame($data['foo'], $associativeArrayMapObject->get('foo'));
         $this->assertTrue($associativeArrayMapObject->removeIf('foo', 123));
         $this->assertFalse($associativeArrayMapObject->containsKey('foo'));
     }
@@ -163,8 +163,8 @@ class AssociativeArrayMapTest extends TestCase
         $associativeArrayMapObject = new AssociativeArrayMap($data);
         $previousValue = $associativeArrayMapObject->replace('foo', 456);
 
-        $this->assertEquals($data['foo'], $previousValue);
-        $this->assertEquals(456, $associativeArrayMapObject->get('foo'));
+        $this->assertSame($data['foo'], $previousValue);
+        $this->assertSame(456, $associativeArrayMapObject->get('foo'));
 
         $previousValue = $associativeArrayMapObject->replace('bar', 789);
         $this->assertNull($previousValue);
@@ -177,8 +177,8 @@ class AssociativeArrayMapTest extends TestCase
         $associativeArrayMapObject = new AssociativeArrayMap($data);
 
         $this->assertFalse($associativeArrayMapObject->replaceIf('foo', 456, 789));
-        $this->assertEquals($data['foo'], $associativeArrayMapObject->get('foo'));
+        $this->assertSame($data['foo'], $associativeArrayMapObject->get('foo'));
         $this->assertTrue($associativeArrayMapObject->replaceIf('foo', 123, 987));
-        $this->assertEquals(987, $associativeArrayMapObject->get('foo'));
+        $this->assertSame(987, $associativeArrayMapObject->get('foo'));
     }
 }

--- a/tests/Map/NamedParameterMapTest.php
+++ b/tests/Map/NamedParameterMapTest.php
@@ -97,7 +97,7 @@ class NamedParameterMapTest extends TestCase
         $namedParameterMap['myMixedNull'] = null;
         $namedParameterMap['myMixedResource'] = fopen('php://memory', 'rb');
 
-        $this->assertEquals(
+        $this->assertSame(
             $expectedParams,
             $namedParameterMap->getNamedParameters()
         );

--- a/tests/Map/TypedMapTest.php
+++ b/tests/Map/TypedMapTest.php
@@ -21,8 +21,8 @@ class TypedMapTest extends TestCase
         $typed = new TypedMap('int', 'string');
 
         $this->assertInstanceOf(TypedMapInterface::class, $typed);
-        $this->assertEquals('int', $typed->getKeyType());
-        $this->assertEquals('string', $typed->getValueType());
+        $this->assertSame('int', $typed->getKeyType());
+        $this->assertSame('string', $typed->getValueType());
         $this->assertEmpty($typed);
         $this->assertCount(0, $typed);
     }
@@ -33,9 +33,9 @@ class TypedMapTest extends TestCase
         $keys = array_keys($content);
         $map = new TypedMap('int', 'string', $content);
 
-        $this->assertEquals($keys, $map->keys());
+        $this->assertSame($keys, $map->keys());
         foreach ($keys as $key) {
-            $this->assertEquals($content[$key], $map->get($key));
+            $this->assertSame($content[$key], $map->get($key));
         }
     }
 
@@ -52,7 +52,7 @@ class TypedMapTest extends TestCase
     {
         $map = new TypedMap('string', 'mixed');
         $map[''] = 'foo';
-        $this->assertEquals([''], $map->keys());
+        $this->assertSame([''], $map->keys());
     }
 
     public function testConstructorAddWrongValueType(): void

--- a/tests/QueueBehavior.php
+++ b/tests/QueueBehavior.php
@@ -24,7 +24,7 @@ trait QueueBehavior
     {
         $queue = $this->queue('integer');
 
-        $this->assertEquals('integer', $queue->getType());
+        $this->assertSame('integer', $queue->getType());
     }
 
     public function testConstructorWithData(): void
@@ -108,7 +108,7 @@ trait QueueBehavior
 
         $id = 0;
         foreach ($queue as $item) {
-            $this->assertEquals($id, $item->id);
+            $this->assertSame($id, $item->id);
             $id++;
         }
     }

--- a/tests/SetTest.php
+++ b/tests/SetTest.php
@@ -40,7 +40,7 @@ class SetTest extends TestCase
     {
         $expected = [2, 4, 6, 8];
         $localSet = new Set('int', $expected);
-        $this->assertEquals($expected, $localSet->toArray());
+        $this->assertSame($expected, $localSet->toArray());
     }
 
     public function testAddDuplicates(): void

--- a/tests/Tool/ValueToStringTraitTest.php
+++ b/tests/Tool/ValueToStringTraitTest.php
@@ -23,25 +23,25 @@ class ValueToStringTraitTest extends TestCase
 
     public function testValueNull(): void
     {
-        $this->assertEquals('NULL', $this->toolValueToString(null));
+        $this->assertSame('NULL', $this->toolValueToString(null));
     }
 
     public function testValueBoolean(): void
     {
-        $this->assertEquals('TRUE', $this->toolValueToString(true));
-        $this->assertEquals('FALSE', $this->toolValueToString(false));
+        $this->assertSame('TRUE', $this->toolValueToString(true));
+        $this->assertSame('FALSE', $this->toolValueToString(false));
     }
 
     public function testValueArray(): void
     {
-        $this->assertEquals('Array', $this->toolValueToString([]));
+        $this->assertSame('Array', $this->toolValueToString([]));
     }
 
     public function testValueScalar(): void
     {
-        $this->assertEquals('', $this->toolValueToString(''));
-        $this->assertEquals('foo', $this->toolValueToString('foo'));
-        $this->assertEquals('9', $this->toolValueToString(9));
+        $this->assertSame('', $this->toolValueToString(''));
+        $this->assertSame('foo', $this->toolValueToString('foo'));
+        $this->assertSame('9', $this->toolValueToString(9));
     }
 
     public function testValueResource(): void
@@ -53,12 +53,12 @@ class ValueToStringTraitTest extends TestCase
 
         $expected = '(' . get_resource_type($resource) . ' resource #' . (int) $resource . ')';
 
-        $this->assertEquals($expected, $this->toolValueToString($resource));
+        $this->assertSame($expected, $this->toolValueToString($resource));
     }
 
     public function testValueObjectWithToString(): void
     {
-        $this->assertEquals('BAZ', $this->toolValueToString(new ObjectWithToString()));
+        $this->assertSame('BAZ', $this->toolValueToString(new ObjectWithToString()));
     }
 
     public function testValueDateTime(): void
@@ -66,7 +66,7 @@ class ValueToStringTraitTest extends TestCase
         // datetimes are objects but are returned as iso dates, not as generic objects
         $expected = '2016-12-31T23:59:59+00:00';
         $date = new DateTimeImmutable('2016-12-31T23:59:59+00:00');
-        $this->assertEquals($expected, $this->toolValueToString($date));
+        $this->assertSame($expected, $this->toolValueToString($date));
     }
 
     public function testValueObject(): void
@@ -76,7 +76,7 @@ class ValueToStringTraitTest extends TestCase
         $value = new stdClass();
         $casted = $this->toolValueToString($value);
 
-        $this->assertEquals($expected, $casted);
+        $this->assertSame($expected, $casted);
     }
 
     public function testValueClosure(): void


### PR DESCRIPTION
## Description

- Improve PHPunit assertions.

## Motivation and context

- Using the `assertFalse` to let expected be `false`.

## How has this been tested?

N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Improvements

## PR checklist
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] I have added tests to cover my changes.
