### PR TITLE
Make different type aliases compaitble in diff, intersect and merge

### DIFF
--- a/src/AbstractCollection.php
+++ b/src/AbstractCollection.php
@@ -258,7 +258,7 @@ abstract class AbstractCollection extends AbstractArray implements CollectionInt
 
             // When using generics (Collection.php, Set.php, etc),
             // we also need to make sure that the internal types match each other
-            if ($collection->getType() !== $this->getType()) {
+            if ($collection->getUniformType() !== $this->getUniformType()) {
                 throw new CollectionMismatchException(
                     sprintf('Collection items in collection with index %d must be of type %s', $index, $this->getType())
                 );
@@ -298,7 +298,7 @@ abstract class AbstractCollection extends AbstractArray implements CollectionInt
 
         // When using generics (Collection.php, Set.php, etc),
         // we also need to make sure that the internal types match each other
-        if ($other->getType() !== $this->getType()) {
+        if ($other->getUniformType() !== $this->getUniformType()) {
             throw new CollectionMismatchException('Collection items must be of type ' . $this->getType());
         }
     }
@@ -322,5 +322,19 @@ abstract class AbstractCollection extends AbstractArray implements CollectionInt
 
                 return $a === $b ? 0 : ($a < $b ? 1 : -1);
             };
+    }
+
+    private function getUniformType(): string
+    {
+        switch ($this->getType()) {
+            case 'integer':
+                return 'int';
+            case 'boolean':
+                return 'bool';
+            case 'double':
+                return 'float';
+            default:
+                return $this->getType();
+        }
     }
 }

--- a/tests/CollectionManipulationTest.php
+++ b/tests/CollectionManipulationTest.php
@@ -452,4 +452,28 @@ class CollectionManipulationTest extends TestCase
         $this->assertSame(['Jane', 'John', 'Janice'], $names->toArray());
         $this->assertSame([1, 2, 3], $ids->toArray());
     }
+
+    public function testWorksUniformlyWithTypeAliases(): void
+    {
+        $collection1 = new Collection('integer', [1, 2, 3]);
+        $collection2 = new Collection('int', [1, 2]);
+
+        $this->assertEquals([3], $collection1->diff($collection2)->toArray());
+        $this->assertEquals([1, 2], $collection1->intersect($collection2)->toArray());
+        $this->assertEquals([1, 2, 3, 1, 2], $collection1->merge($collection2)->toArray());
+
+        $collection1 = new Collection('float', [1.5, 2.5, 3.5]);
+        $collection2 = new Collection('double', [1.5, 2.5]);
+
+        $this->assertEquals([3.5], $collection1->diff($collection2)->toArray());
+        $this->assertEquals([1.5, 2.5], $collection1->intersect($collection2)->toArray());
+        $this->assertEquals([1.5, 2.5, 3.5, 1.5, 2.5], $collection1->merge($collection2)->toArray());
+
+        $collection1 = new Collection('bool', [true]);
+        $collection2 = new Collection('boolean', [false]);
+
+        $this->assertEquals([true, false], $collection1->diff($collection2)->toArray());
+        $this->assertEquals([], $collection1->intersect($collection2)->toArray());
+        $this->assertEquals([true, false], $collection1->merge($collection2)->toArray());
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Make it works when calling `diff`, `intersect` or `merge` on two collections having the same type but with different aliases like `int` and `integer`

**This applies on:**
int, integer
bool, boolean
float, double

## Motivation and context

Code like this should work without having to construct both collections as `int` or `integer`

```
(new Collection('integer', [1, 2, 3]))->diff(new Collection('int', [1, 2]));
```

## How has this been tested?
I added a method to test it in CollectionManipulationTest

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
