### PR TITLE
fix(set): map uniqueness

### DIFF
--- a/src/AbstractCollection.php
+++ b/src/AbstractCollection.php
@@ -55,6 +55,11 @@ abstract class AbstractCollection extends AbstractArray implements CollectionInt
     use ValueExtractorTrait;
 
     /**
+     * @var class-string<CollectionInterface<T>>
+     */
+    protected string $collection = Collection::class;
+
+    /**
      * @throws InvalidArgumentException if $element is of the wrong type.
      */
     public function add(mixed $element): bool
@@ -230,7 +235,7 @@ abstract class AbstractCollection extends AbstractArray implements CollectionInt
     public function map(callable $callback): CollectionInterface
     {
         /** @var Collection<TCallbackReturn> */
-        return new Collection('mixed', array_map($callback, $this->data));
+        return new $this->collection('mixed', array_map($callback, $this->data));
     }
 
     /**

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -76,6 +76,11 @@ namespace Ramsey\Collection;
 class Collection extends AbstractCollection
 {
     /**
+     * @psalm-suppress NonInvariantDocblockPropertyType
+     */
+    protected string $collection = self::class;
+
+    /**
      * Constructs a collection object of the specified type, optionally with the
      * specified data.
      *

--- a/src/Set.php
+++ b/src/Set.php
@@ -41,6 +41,11 @@ namespace Ramsey\Collection;
 class Set extends AbstractSet
 {
     /**
+     * @psalm-suppress NonInvariantDocblockPropertyType
+     */
+    protected string $collection = self::class;
+
+    /**
      * Constructs a set object of the specified type, optionally with the
      * specified data.
      *

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -75,6 +75,13 @@ class CollectionTest extends TestCase
         $this->assertTrue($collection->add($this->faker->numberBetween()));
     }
 
+    public function testMapWillReturnANewCollection(): void
+    {
+        $collection = (new Collection('integer', [4, 2]))->map(fn ($value) => $value);
+
+        $this->assertInstanceOf(Collection::class, $collection);
+    }
+
     public function testAddMayAddSameObjectMultipleTimes(): void
     {
         $expectedCount = 4;

--- a/tests/SetTest.php
+++ b/tests/SetTest.php
@@ -94,6 +94,16 @@ class SetTest extends TestCase
         $this->assertSame(['X', 'Y', 'Z'], $set3->toArray());
     }
 
+    public function testDuplicatesViaMap(): void
+    {
+        $this->assertTrue($this->set->add(100));
+        $this->assertTrue($this->set->add(200));
+
+        $set = $this->set->map(fn () => 200);
+
+        $this->assertSame([200], $set->toArray());
+    }
+
     public function testMergingSetsOfObjects(): void
     {
         $obj1 = new Foo();

--- a/tests/SetTest.php
+++ b/tests/SetTest.php
@@ -104,6 +104,16 @@ class SetTest extends TestCase
         $this->assertSame([200], $set->toArray());
     }
 
+    public function testMapReturnsANewSet(): void
+    {
+        $this->assertTrue($this->set->add(100));
+        $this->assertTrue($this->set->add(200));
+
+        $set = $this->set->map(fn ($value) => $value);
+
+        $this->assertInstanceOf(Set::class, $set);
+    }
+
     public function testMergingSetsOfObjects(): void
     {
         $obj1 = new Foo();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->
When mapping over a set it is possible to introduce duplicate values which is undesirable.
```php
$set = new \Ramsey\Collection\Set('integer', [1, 2, 3]);
$set->map(fn () => 42);
```

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is so that the behavior of the implementation is respected such as in this case the duplicate values in a `Set`. 
## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests have been added for the `Set` and `Collection` implementations that a instance of themselves is returned and that when mapping over an existing `Set` not duplicate values can be introduced. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
The actual return types as declared have not changed but in the case of the `Set` a new `Set` is now returned instead of a `Collection` as well as the new mapping behavior for the `Set` that does now not allow duplicate values anymore.

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] I have added tests to cover my changes.
