### PR TITLE
fix(value-extractor-trait): Fix #122

### DIFF
--- a/src/Tool/ValueExtractorTrait.php
+++ b/src/Tool/ValueExtractorTrait.php
@@ -16,6 +16,7 @@ namespace Ramsey\Collection\Tool;
 
 use Ramsey\Collection\Exception\InvalidPropertyOrMethod;
 use Ramsey\Collection\Exception\UnsupportedOperationException;
+use ReflectionProperty;
 
 use function is_array;
 use function is_object;
@@ -62,6 +63,15 @@ trait ValueExtractorTrait
                 'Key or index "%s" not found in collection elements',
                 $propertyOrMethod,
             ));
+        }
+
+        if (property_exists($element, $propertyOrMethod) && method_exists($element, $propertyOrMethod)) {
+            $reflectionProperty = new ReflectionProperty($element, $propertyOrMethod);
+            if ($reflectionProperty->isPublic()) {
+                return $element->$propertyOrMethod;
+            }
+
+            return $element->{$propertyOrMethod}();
         }
 
         if (property_exists($element, $propertyOrMethod)) {

--- a/tests/Tool/ValueExtractorTraitTest.php
+++ b/tests/Tool/ValueExtractorTraitTest.php
@@ -88,4 +88,67 @@ class ValueExtractorTraitTest extends TestCase
 
         $this->assertSame('works!', $test('testProperty'), 'Could not extract value by property');
     }
+
+    public function testShouldExtractValueByMethodWhenPrivatePropertyExistsWithSameName(): void
+    {
+        $test = new class {
+            use ValueExtractorTrait;
+
+            /**
+             * @return mixed
+             */
+            public function __invoke(mixed $element, string $propertyOrMethod)
+            {
+                return $this->extractValue($element, $propertyOrMethod);
+            }
+
+            public function getType(): string
+            {
+                return 'fudge';
+            }
+        };
+
+        $element = new class {
+            private string $testProperty = 'works!';
+
+            public function testProperty(): string
+            {
+                return $this->testProperty;
+            }
+        };
+
+        $this->assertSame('works!', $test($element, 'testProperty'), 'Could not extract value by method');
+    }
+
+    public function testShouldExtractValueByPropertyWhenPrivateMethodExistsWithSameName(): void
+    {
+        $test = new class {
+            use ValueExtractorTrait;
+
+            /**
+             * @return mixed
+             */
+            public function __invoke(mixed $element, string $propertyOrMethod)
+            {
+                return $this->extractValue($element, $propertyOrMethod);
+            }
+
+            public function getType(): string
+            {
+                return 'fudge';
+            }
+        };
+
+        $element = new class {
+            public string $testProperty = 'works!';
+
+            /** @phpstan-ignore-next-line */
+            private function testProperty(): string
+            {
+                return 'does not work!';
+            }
+        };
+
+        $this->assertSame('works!', $test($element, 'testProperty'), 'Could not extract value by property');
+    }
 }


### PR DESCRIPTION
This will allow elements to have values extracted from them if they have a private property and public method with teh same name. See #122 

Right now the value extractor fails as soon as it tries to access the private property, and does not extract the value from the public method.

## Description
This adds some reflection to first check if the property is public, and if not tries the method. To minimize performance impact it only does this if both a property and method of the same name exist. 

## How has this been tested?
Added the test cases exposing the bug, then implemented the fix.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
