### PR TITLE
ci: Add PHP version 8.5 to CI workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -101,6 +101,7 @@ jobs:
           - "8.2"
           - "8.3"
           - "8.4"
+          - "8.5"
 
     steps:
       - name: "Checkout repository"


### PR DESCRIPTION
blocked by 
`phpspec/prophecy`